### PR TITLE
Overhaul qualitative evaluators to separate raw and per-experiment metrics

### DIFF
--- a/dmcaf/condition_generator.py
+++ b/dmcaf/condition_generator.py
@@ -117,7 +117,7 @@ class ConditionGenerator:
             number = random.choice(list(range(1, 5)))
             obj_singular = random.choice(selected_objects)
             obj_display = self.singular_to_plural[obj_singular] if number > 1 else obj_singular
-            prompt = f"{number} {obj_display} in front of unicolor background"
+            prompt = f"a photo of {number} {obj_display} in front of unicolor background"
             cursor.execute("""
                 INSERT INTO conditions (experiment_id, type, prompt, number, object, background, timestamp)
                 VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/dmcaf/condition_generator.py
+++ b/dmcaf/condition_generator.py
@@ -117,7 +117,7 @@ class ConditionGenerator:
             number = random.choice(list(range(1, 5)))
             obj_singular = random.choice(selected_objects)
             obj_display = self.singular_to_plural[obj_singular] if number > 1 else obj_singular
-            prompt = f"Zoomed out photo of {number} {obj_display} centered in front of unicolor background"
+            prompt = f"{number} {obj_display} in front of unicolor background"
             cursor.execute("""
                 INSERT INTO conditions (experiment_id, type, prompt, number, object, background, timestamp)
                 VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/dmcaf/object_count.py
+++ b/dmcaf/object_count.py
@@ -4,13 +4,13 @@ import cv2
 from typing import Optional, List, Dict, Any
 
 class ObjectCounter:
-    def __init__(self, model_path='yolo11n.pt'):
+    def __init__(self, model_path='yolo12s.pt'):
         """
         Initializes the ObjectCounter with a YOLO model.
         """
         self.model = YOLO(model_path)
 
-    def count_objects_in_image(self, image_path: str, output_path: str = None, target_object: Optional[str] = None) -> int:
+    def count_objects_in_image(self, image_path: str, target_object: Optional[str] = None) -> int:
         """
         Counts objects in an image, optionally filtering for a specific object.
         """


### PR DESCRIPTION
Now a raw_metrics table is present for individiual accuracy scores and experiment_metrics holds the experiment wide metrics like FID or avg of qualitative accuracy scores